### PR TITLE
Add toggle functionality to inputs

### DIFF
--- a/octoprint_enclosure/__init__.py
+++ b/octoprint_enclosure/__init__.py
@@ -461,7 +461,10 @@ class EnclosurePlugin(octoprint.plugin.StartupPlugin,
                 ((rpi_input['edge']=='fall') ^ GPIO.input(self.toInt(rpi_input['gpioPin']))):
                     for rpi_output in self.rpi_outputs:
                         if self.toInt(rpi_input['controlledIO']) == self.toInt(rpi_output['gpioPin']) and rpi_output['outputType']=='regular':
-                            val = GPIO.LOW if rpi_input['setControlledIO']=='low' else GPIO.HIGH
+                            if rpi_input['setControlledIO']=='toggle':
+                                val = GPIO.LOW if GPIO.input(self.toInt(rpi_output['gpioPin']))==GPIO.HIGH else GPIO.HIGH
+                            else:
+                                val = GPIO.LOW if rpi_input['setControlledIO']=='low' else GPIO.HIGH
                             self.writeGPIO(self.toInt(rpi_output['gpioPin']),val)
                             for notification in self.notifications:
                                 if notification['gpioAction']:

--- a/octoprint_enclosure/templates/enclosure_settings.jinja2
+++ b/octoprint_enclosure/templates/enclosure_settings.jinja2
@@ -375,6 +375,7 @@
             <select data-bind="value: setControlledIO">
               <option value="low">Low</option>
               <option value="high">High</option>
+              <option value="toggle">Toggle</option>
             </select>
             <span class="help-inline">When the event happen, you want to turn the controlled IO HIGH or LOW?</span>
           </div>


### PR DESCRIPTION
I've added code to set the controlled IO value for 'Raspberry Pi Inputs' to Toggle. This toggles the value between GPIO.HIGH and GPIO.LOW, depending on the current state.

I am currently using this functionality for a light-switch, which enables and disables a relay. It is fully tested and works.