### PR TITLE
Hide humidity if not available

### DIFF
--- a/octoprint_enclosure/templates/enclosure_tab.jinja2
+++ b/octoprint_enclosure/templates/enclosure_tab.jinja2
@@ -37,7 +37,7 @@
           </div>
         </td>
       </tr>
-      <tr>
+      <tr data-bind="visible: $root.enclosureHumidity">
         <th style="vertical-align: middle">{{ _('Humidity') }}</th>
         <td style="text-align: right; vertical-align: middle">
           <span data-bind="html: $root.enclosureHumidity"></span>


### PR DESCRIPTION
If the enclosure sensor doesn't provide humidity it returns 0, so this can be used to hide the humidity row from the table.