### PR TITLE
added MAX31855 support

### DIFF
--- a/octoprint_enclosure/max31855.py
+++ b/octoprint_enclosure/max31855.py
@@ -1,0 +1,27 @@
+import ctypes
+import struct
+import sys
+
+import Adafruit_GPIO.SPI as SPI
+import Adafruit_MAX31855.MAX31855 as MAX31855
+
+
+def main():
+    # Get bus address if provided or use default address
+    SPI_DEVICE = 0
+    if len(sys.argv) >= 2:
+        SPI_DEVICE = int(sys.argv[1], 0)
+
+    if not 0 <= SPI_DEVICE <= 1:
+        raise ValueError("Invalid address value")
+
+   # Raspberry Pi hardware SPI configuration.
+    SPI_PORT   = 0
+    sensor = MAX31855.MAX31855(spi=SPI.SpiDev(SPI_PORT, SPI_DEVICE))
+
+    temp = sensor.readTempC()
+
+    print('{0:0.1f}'.format(temp))
+
+if __name__ == "__main__":
+    main()

--- a/octoprint_enclosure/templates/enclosure_settings.jinja2
+++ b/octoprint_enclosure/templates/enclosure_settings.jinja2
@@ -536,6 +536,7 @@
             <option value="si7021">SI7021</option>
             <option value="bme280">BME280</option>
             <option value="tmp102">TMP102</option>
+            <option value="max31855">MAX31855</option>
           </select>
           <span class="help-inline">
             <span class="label label-important">Attention</span> You need to install and configure the necessary libraries for the temperature sensor, check
@@ -579,7 +580,30 @@
         </div>
       </div>
       <!-- /ko -->
-      <!-- ko ifnot: ($data.temp_sensor_type() == "18b20") || ($data.temp_sensor_type() == "si7021") || ($data.temp_sensor_type() == "bme280") || ($data.temp_sensor_type() == "tmp102") -->
+      <!-- ko if: ($data.temp_sensor_type() == "max31855") -->
+      <div class="control-group">
+        <label class="control-label" for="settings-enclosure-dhtPin">{{ _('Sensor Pin') }}</label>
+        <div class="controls">
+          <input type="text" class="input-block-level" value="MISO / SCLK" disabled="true">
+          <span class="help-inline">GPIO pin for temperature sensor need to connect the sensor to SPI. Serial Clock to GPIO 1 (SCLK) and Master In/Slave Out Data to GPIO
+            9 (MISO)
+          </span>
+        </div>
+      </div>
+      <div class="control-group">
+        <label class="control-label" for="settings-enclosure-dhtPin">{{ _('Sensor Address (CE Select)') }}</label>
+        <div class="controls">
+          <select data-bind="value: temp_sensor_address">
+            <option value="">Select CE</option>
+            <option value="0">CE0</option>
+            <option value="1">CE1</option>
+          </select>
+          <span class="help-inline">CE select: CE0 on GPIO 8 or CE1 on GPIO 7</span>
+        </div>
+      </div>
+      
+      <!-- /ko -->
+      <!-- ko ifnot: ($data.temp_sensor_type() == "18b20") || ($data.temp_sensor_type() == "si7021") || ($data.temp_sensor_type() == "bme280") || ($data.temp_sensor_type() == "tmp102") || ($data.temp_sensor_type() == "max31855") -->
       <div class="control-group">
         <label class="control-label" for="settings-enclosure-dhtPin">{{ _('Sensor Pin') }}</label>
         <div class="controls">


### PR DESCRIPTION
Bare TC measurement is way better in free air than any of the supported sensors. Therefore, I used a MAX31855PMB1 and added support for the MAX31855 chip to OctoPrint-Enclosure.