### PR TITLE
Temporary fix for PWM, Spelling mistakes and debug messages

### DIFF
--- a/octoprint_enclosure/__init__.py
+++ b/octoprint_enclosure/__init__.py
@@ -916,7 +916,7 @@ class EnclosurePlugin(octoprint.plugin.StartupPlugin,
             self.log_error(ex)
 
     def clear_channel(self, channel):
-        self._logging.debug("Clearing channel: %s", channel)
+        self._logger.debug("Clearing channel: %s", channel)
         try:
             GPIO.cleanup(self.to_int(channel))
         except Exception as ex:
@@ -946,6 +946,7 @@ class EnclosurePlugin(octoprint.plugin.StartupPlugin,
                 self._logger.info("Setting GPIO pin %s as PWM", pin)
 
                 for pwm in (pwm_dict for pwm_dict in self.pwm_intances if pin in pwm_dict):
+                    pwm.stop()
                     self.pwm_intances.remove(pwm)
                 self.clear_channel(pin)
                 try:

--- a/octoprint_enclosure/__init__.py
+++ b/octoprint_enclosure/__init__.py
@@ -753,8 +753,8 @@ class EnclosurePlugin(octoprint.plugin.StartupPlugin,
                     except:
                         calculated_duty = 0
 
-                    if self._settings.get(["debug"]) is True:
-                        self._logger.info(
+
+                    self._logger.info(
                             "Calculated duty for PWM %s is %s", index_id, calculated_duty)
                 elif self.print_complete:
                     calculated_duty = self.to_int(pwm_output['duty_cycle'])

--- a/octoprint_enclosure/__init__.py
+++ b/octoprint_enclosure/__init__.py
@@ -1214,6 +1214,8 @@ class EnclosurePlugin(octoprint.plugin.StartupPlugin,
                     old_pwm_value = pwm['duty_cycle'] if 'duty_cycle' in pwm else -1
                     if not self.to_int(old_pwm_value) == self.to_int(pwm_value):
                         pwm['duty_cycle'] = pwm_value
+                        self._logger.debug("Changing duty cycle: %s", pwm_value)
+                        self._logger.debug("PWM Object is: %s", pwm_object)
                         pwm_object.ChangeDutyCycle(pwm_value)
                         self._logger.debug(
                                 "Writing PWM on gpio: %s value %s", gpio, pwm_value)

--- a/octoprint_enclosure/__init__.py
+++ b/octoprint_enclosure/__init__.py
@@ -1207,8 +1207,9 @@ class EnclosurePlugin(octoprint.plugin.StartupPlugin,
         try:
             if queue_id is not None and self._settings.get(["debug"]) is True:
                 self._logger.info("Running scheduled queue id %s", queue_id)
+            self._logger.debug("pwm_instances: %s", self.pwm_intances)
             for pwm in self.pwm_intances:
-                self._logger.debug("pwm: %s", pwm)
+                self._logger.debug("is gpio in pwm? : %s", (gpio in pwm))
                 if gpio in pwm:
                     pwm_object = pwm[gpio]
                     old_pwm_value = pwm['duty_cycle'] if 'duty_cycle' in pwm else -1

--- a/octoprint_enclosure/__init__.py
+++ b/octoprint_enclosure/__init__.py
@@ -946,7 +946,7 @@ class EnclosurePlugin(octoprint.plugin.StartupPlugin,
                 self._logger.info("Setting GPIO pin %s as PWM", pin)
 
                 for pwm in (pwm_dict for pwm_dict in self.pwm_intances if pin in pwm_dict):
-                    pwm.stop()
+                    pwm[pin].stop()
                     self.pwm_intances.remove(pwm)
                 self.clear_channel(pin)
                 try:

--- a/octoprint_enclosure/__init__.py
+++ b/octoprint_enclosure/__init__.py
@@ -1202,7 +1202,7 @@ class EnclosurePlugin(octoprint.plugin.StartupPlugin,
             pass
 
     def write_pwm(self, gpio, pwm_value, queue_id=None):
-        gpio =int(gpio)
+        pwm_value =int(pwm_value)
         self._logger.debug("Calling write_pwm: %s, %s ,%s", gpio, pwm_value, queue_id)
         try:
             if queue_id is not None and self._settings.get(["debug"]) is True:

--- a/octoprint_enclosure/__init__.py
+++ b/octoprint_enclosure/__init__.py
@@ -1202,18 +1202,19 @@ class EnclosurePlugin(octoprint.plugin.StartupPlugin,
             pass
 
     def write_pwm(self, gpio, pwm_value, queue_id=None):
+        self.logger.debug("Calling write_pwm: %s, %s ,%s", gpio, pwm_value, queue_id)
         try:
             if queue_id is not None and self._settings.get(["debug"]) is True:
-                self._logger.info("Runing scheduled queue id %s", queue_id)
+                self._logger.info("Running scheduled queue id %s", queue_id)
             for pwm in self.pwm_intances:
+                self.logger.debug("pwm: %s", pwm)
                 if gpio in pwm:
                     pwm_object = pwm[gpio]
                     old_pwm_value = pwm['duty_cycle'] if 'duty_cycle' in pwm else -1
                     if not self.to_int(old_pwm_value) == self.to_int(pwm_value):
                         pwm['duty_cycle'] = pwm_value
                         pwm_object.ChangeDutyCycle(pwm_value)
-                        if self._settings.get(["debug"]) is True:
-                            self._logger.info(
+                        self._logger.debug(
                                 "Writing PWM on gpio: %s value %s", gpio, pwm_value)
                     self.update_ui()
                     if queue_id is not None:

--- a/octoprint_enclosure/__init__.py
+++ b/octoprint_enclosure/__init__.py
@@ -1202,12 +1202,12 @@ class EnclosurePlugin(octoprint.plugin.StartupPlugin,
             pass
 
     def write_pwm(self, gpio, pwm_value, queue_id=None):
-        self.logger.debug("Calling write_pwm: %s, %s ,%s", gpio, pwm_value, queue_id)
+        self._logger.debug("Calling write_pwm: %s, %s ,%s", gpio, pwm_value, queue_id)
         try:
             if queue_id is not None and self._settings.get(["debug"]) is True:
                 self._logger.info("Running scheduled queue id %s", queue_id)
             for pwm in self.pwm_intances:
-                self.logger.debug("pwm: %s", pwm)
+                self._logger.debug("pwm: %s", pwm)
                 if gpio in pwm:
                     pwm_object = pwm[gpio]
                     old_pwm_value = pwm['duty_cycle'] if 'duty_cycle' in pwm else -1

--- a/octoprint_enclosure/__init__.py
+++ b/octoprint_enclosure/__init__.py
@@ -734,7 +734,7 @@ class EnclosurePlugin(octoprint.plugin.StartupPlugin,
         try:
             for pwm_output in list(filter(lambda item: item['output_type'] == 'pwm' and item['pwm_temperature_linked'], self.rpi_outputs)):
                 gpio_pin = self.to_int(pwm_output['gpio_pin'])
-                if self._printer.is_printing():
+                if True==True: #if self._printer.is_printing():
                     index_id = self.to_int(pwm_output['index_id'])
                     linked_id = self.to_int(pwm_output['linked_temp_sensor'])
                     linked_data = self.get_linked_temp_sensor_data(

--- a/octoprint_enclosure/__init__.py
+++ b/octoprint_enclosure/__init__.py
@@ -1202,6 +1202,7 @@ class EnclosurePlugin(octoprint.plugin.StartupPlugin,
             pass
 
     def write_pwm(self, gpio, pwm_value, queue_id=None):
+        gpio =int(gpio)
         self._logger.debug("Calling write_pwm: %s, %s ,%s", gpio, pwm_value, queue_id)
         try:
             if queue_id is not None and self._settings.get(["debug"]) is True:

--- a/octoprint_enclosure/__init__.py
+++ b/octoprint_enclosure/__init__.py
@@ -343,7 +343,7 @@ class EnclosurePlugin(octoprint.plugin.StartupPlugin, octoprint.plugin.TemplateP
             sensor_data = []
             for sensor in list(filter(lambda item: item['input_type'] == 'temperature_sensor', self.rpi_inputs)):
                 temp, hum = self.get_sensor_data(sensor)
-                if self._settings.get(["debug"]) is True and self._settings.get(["debug_temperature_log"]) is True:
+                if  self._settings.get(["debug_temperature_log"]) is True:
                     self._logger.debug("Sensor %s Temperature: %s humidity %s", sensor['label'], temp, hum)
                 if temp is not None and hum is not None:
                     sensor_data.append(dict(index_id=sensor['index_id'], temperature=temp, humidity=hum))
@@ -564,10 +564,10 @@ class EnclosurePlugin(octoprint.plugin.StartupPlugin, octoprint.plugin.TemplateP
             else:
                 sudo_str = ""
             cmd = sudo_str + "python " + script + str(sensor) + " " + str(pin)
-            if self._settings.get(["debug"]) is True and self._settings.get(["debug_temperature_log"]) is True:
+            if  self._settings.get(["debug_temperature_log"]) is True:
                 self._logger.debug("Temperature dht cmd: %s", cmd)
             stdout = (Popen(cmd, shell=True, stdout=PIPE).stdout).read()
-            if self._settings.get(["debug"]) is True and self._settings.get(["debug_temperature_log"]) is True:
+            if  self._settings.get(["debug_temperature_log"]) is True:
                 self._logger.debug("Dht result: %s", stdout)
             temp, hum = stdout.split("|")
             return (self.to_float(temp.strip()), self.to_float(hum.strip()))
@@ -585,10 +585,10 @@ class EnclosurePlugin(octoprint.plugin.StartupPlugin, octoprint.plugin.TemplateP
             else:
                 sudo_str = ""
             cmd = sudo_str + "python " + script + str(address)
-            if self._settings.get(["debug"]) is True and self._settings.get(["debug_temperature_log"]) is True:
+            if  self._settings.get(["debug_temperature_log"]) is True:
                 self._logger.debug("Temperature BME280 cmd: %s", cmd)
             stdout = (Popen(cmd, shell=True, stdout=PIPE).stdout).read()
-            if self._settings.get(["debug"]) is True and self._settings.get(["debug_temperature_log"]) is True:
+            if  self._settings.get(["debug_temperature_log"]) is True:
                 self._logger.debug("BME280 result: %s", stdout)
             temp, hum = stdout.split("|")
             return (self.to_float(temp.strip()), self.to_float(hum.strip()))
@@ -606,10 +606,10 @@ class EnclosurePlugin(octoprint.plugin.StartupPlugin, octoprint.plugin.TemplateP
             else:
                 sudo_str = ""
             cmd = sudo_str + "python " + script + str(address)
-            if self._settings.get(["debug"]) is True and self._settings.get(["debug_temperature_log"]) is True:
+            if  self._settings.get(["debug_temperature_log"]) is True:
                 self._logger.debug("Temperature SI7021 cmd: %s", cmd)
             stdout = (Popen(cmd, shell=True, stdout=PIPE).stdout).read()
-            if self._settings.get(["debug"]) is True and self._settings.get(["debug_temperature_log"]) is True:
+            if  self._settings.get(["debug_temperature_log"]) is True:
                 self._logger.debug("SI7021 result: %s", stdout)
             temp, hum = stdout.split("|")
             return (self.to_float(temp.strip()), self.to_float(hum.strip()))
@@ -631,7 +631,7 @@ class EnclosurePlugin(octoprint.plugin.StartupPlugin, octoprint.plugin.TemplateP
         if equals_pos != -1:
             temp_string = lines[1][equals_pos + 2:]
             temp_c = float(temp_string) / 1000.
-            if self._settings.get(["debug"]) is True and self._settings.get(["debug_temperature_log"]) is True:
+            if  self._settings.get(["debug_temperature_log"]) is True:
                 self._logger.debug("DS18B20 result: %s", temp_c)
             return '{0:0.1f}'.format(temp_c)
         return 0
@@ -649,11 +649,11 @@ class EnclosurePlugin(octoprint.plugin.StartupPlugin, octoprint.plugin.TemplateP
         try:
             script = os.path.dirname(os.path.realpath(__file__)) + "/tmp102.py"
             args = ["python", script, str(address)]
-            if self._settings.get(["debug"]) is True and self._settings.get(["debug_temperature_log"]) is True:
+            if  self._settings.get(["debug_temperature_log"]) is True:
                 self._logger.debug("Temperature TMP102 cmd: %s", " ".join(args))
             proc = Popen(args, stdout=PIPE)
             stdout, _ = proc.communicate()
-            if self._settings.get(["debug"]) is True and self._settings.get(["debug_temperature_log"]) is True:
+            if  self._settings.get(["debug_temperature_log"]) is True:
                 self._logger.debug("TMP102 result: %s", stdout)
             return self.to_float(stdout.strip())
         except Exception as ex:
@@ -665,11 +665,11 @@ class EnclosurePlugin(octoprint.plugin.StartupPlugin, octoprint.plugin.TemplateP
         try:
             script = os.path.dirname(os.path.realpath(__file__)) + "/max31855.py"
             args = ["python", script, str(address)]
-            if self._settings.get(["debug"]) is True and self._settings.get(["debug_temperature_log"]) is True:
+            if  self._settings.get(["debug_temperature_log"]) is True:
                 self._logger.debug("Temperature MAX31855 cmd: %s", " ".join(args))
             proc = Popen(args, stdout=PIPE)
             stdout, _ = proc.communicate()
-            if self._settings.get(["debug"]) is True and self._settings.get(["debug_temperature_log"]) is True:
+            if  self._settings.get(["debug_temperature_log"]) is True:
                 self._logger.debug("MAX31855 result: %s", stdout)
             return self.to_float(stdout.strip())
         except Exception as ex:
@@ -842,6 +842,7 @@ class EnclosurePlugin(octoprint.plugin.StartupPlugin, octoprint.plugin.TemplateP
     def clear_channel(self, channel):
         try:
             GPIO.cleanup(self.to_int(channel))
+            self._logger.debug("Clearing channel %s", channel)
         except Exception as ex:
             self.log_error(ex)
 
@@ -1116,7 +1117,8 @@ class EnclosurePlugin(octoprint.plugin.StartupPlugin, octoprint.plugin.TemplateP
                     old_pwm_value = pwm['duty_cycle'] if 'duty_cycle' in pwm else -1
                     if not self.to_int(old_pwm_value) == self.to_int(pwm_value):
                         pwm['duty_cycle'] = pwm_value
-                        pwm_object.start(pwm_value)
+                        pwm_object.start(pwm_value) #should be changed back to pwm_object.ChangeDutyCycle() but this
+                        # was causing errors.
                         self._logger.debug("Writing PWM on gpio: %s value %s", gpio, pwm_value)
                     self.update_ui()
                     if queue_id is not None:

--- a/octoprint_enclosure/__init__.py
+++ b/octoprint_enclosure/__init__.py
@@ -1226,10 +1226,9 @@ class EnclosurePlugin(octoprint.plugin.StartupPlugin,
                     pwm['duty_cycle'] = pwm_value
                     self._logger.debug("Changing duty cycle: %s", pwm_value)
                     self._logger.debug("PWM Object is: %s", pwm_object)
-                    pwm_object.ChangeDutyCycle(pwm_value)
+                    pwm_object.start(pwm_value)
                     self._logger.debug(
                             "Writing PWM on gpio: %s value %s", gpio, pwm_value)
-
 
                     self.update_ui()
                     if queue_id is not None:

--- a/octoprint_enclosure/__init__.py
+++ b/octoprint_enclosure/__init__.py
@@ -1221,13 +1221,16 @@ class EnclosurePlugin(octoprint.plugin.StartupPlugin,
                 if gpio in pwm:
                     pwm_object = pwm[gpio]
                     old_pwm_value = pwm['duty_cycle'] if 'duty_cycle' in pwm else -1
-                    if not self.to_int(old_pwm_value) == self.to_int(pwm_value):
-                        pwm['duty_cycle'] = pwm_value
-                        self._logger.debug("Changing duty cycle: %s", pwm_value)
-                        self._logger.debug("PWM Object is: %s", pwm_object)
-                        pwm_object.ChangeDutyCycle(pwm_value)
-                        self._logger.debug(
-                                "Writing PWM on gpio: %s value %s", gpio, pwm_value)
+
+
+                    pwm['duty_cycle'] = pwm_value
+                    self._logger.debug("Changing duty cycle: %s", pwm_value)
+                    self._logger.debug("PWM Object is: %s", pwm_object)
+                    pwm_object.ChangeDutyCycle(pwm_value)
+                    self._logger.debug(
+                            "Writing PWM on gpio: %s value %s", gpio, pwm_value)
+
+
                     self.update_ui()
                     if queue_id is not None:
                         self.stop_queue_item(queue_id)

--- a/octoprint_enclosure/templates/enclosure_settings.jinja2
+++ b/octoprint_enclosure/templates/enclosure_settings.jinja2
@@ -101,8 +101,9 @@
         <!-- /ko -->
         <!-- ko if: ($data.output_type() == "neopixel_indirect")  -->
         <span class="help-inline">
-          <span class="label label-danger">Attention</span> Neopixel requires a microcontroler (ex: arduino) connected to I2C bus. This is the pin on the
-          microcontroler that is connected to the Neopixel.
+          <span class="label label-danger">Attention</span> Neopixel requires a microcontroller (ex: arduino) 
+            connected to I2C bus. This is the pin on the
+          microcontroller that is connected to the Neopixel.
         </span>
         <!-- /ko -->
       </div>
@@ -116,7 +117,7 @@
           <input type="checkbox" data-bind="checked: pwm_temperature_linked"> {{ _('Link PWM to Temperature') }}
         </label>
         <span class="help-inline">Link PWM ouput to temperature. PWM output will be interpolated between the point from duty A, temperature A -> duty
-          B, temperature B. This output will automatomatically start when a print starts and will default to the default
+          B, temperature B. This output will automatically start when a print starts and will default to the default
           duty cycle when print is complete.
         </span>
       </div>
@@ -156,7 +157,7 @@
         <label class="checkbox">
           <input type="checkbox" data-bind="checked: toggle_timer"> {{ _('Timer Toggle') }}
         </label>
-        <span class="help-inline">Toggle output every amount of secconds. It will start when the print starts and stop when print is complete. For
+        <span class="help-inline">Toggle output every amount of seconds. It will start when the print starts and stop when print is complete. For
           PWM pins it will use the default PWM value when ON.
         </span>
       </div>
@@ -166,7 +167,7 @@
       <label class="control-label">{{ _('On Time') }}</label>
       <div class="controls">
         <input type="text" class="input-block-level" data-bind="value: toggle_timer_on">
-        <span class="help-inline">Time in secconds that the GPIO will remain ON</span>
+        <span class="help-inline">Time in seconds that the GPIO will remain ON</span>
       </div>
     </div>
     <div class="control-group">
@@ -188,7 +189,7 @@
         <label class="checkbox">
           <input type="checkbox" data-bind="checked: startup_with_server"> {{ _('Start with server') }}
         </label>
-        <span class="help-inline">Choose if output should turn on automatomatically when octoprint starts</span>
+        <span class="help-inline">Choose if output should turn on automatically when octoprint starts</span>
       </div>
     </div>
     <div class="control-group">
@@ -196,7 +197,7 @@
         <label class="checkbox">
           <input type="checkbox" data-bind="checked: auto_startup"> {{ _('Auto Startup') }}
         </label>
-        <span class="help-inline">Choose if output should turn on automatomatically when print starts</span>
+        <span class="help-inline">Choose if output should turn on automatically when print starts</span>
       </div>
     </div>
     <!-- /ko -->
@@ -206,7 +207,7 @@
         <label class="control-label">{{ _('Startup Delay / Hour') }}</label>
         <div class="controls">
           <input type="text" class="input-block-level" data-bind="value: startup_time">
-          <span class="help-inline">Time delay in secconds to turn on GPIO when print starts OR exact time that the event should happen, note that
+          <span class="help-inline">Time delay in seconds to turn on GPIO when print starts OR exact time that the event should happen, note that
             events will only be scheduled after a print starts, time should be formated as HH:MM on a 24 hours format, don't
             forget to check timezone of your Raspberry Pi.</span>
         </div>
@@ -257,7 +258,7 @@
         <label class="checkbox">
           <input type="checkbox" data-bind="checked: active_low"> {{ _('Active Low') }}
         </label>
-        <span class="help-inline">Active low means that the GPIO will turn on when receive a low signal (ground) from Raspbery PI</span>
+        <span class="help-inline">Active low means that the GPIO will turn on when receive a low signal (ground) from Raspberry PI</span>
       </div>
     </div>
     <!-- /ko -->
@@ -406,7 +407,7 @@
       <label class="control-label" for="settings-enclosure-dhtPin">{{ _('Microcontroller Address') }}</label>
       <div class="controls">
         <input type="text" class="input-block-level" data-bind="value: microcontroller_address">
-        <span class="help-inline">Microcontroller address in HEX value, you can find it by runing
+        <span class="help-inline">Microcontroller address in HEX value, you can find it by running
           <code>i2cdetect -y 1</code> on your Raspberry Pi</span>
       </div>
     </div>
@@ -575,7 +576,7 @@
         <label class="control-label" for="settings-enclosure-dhtPin">{{ _('Sensor Address') }}</label>
         <div class="controls">
           <input type="text" class="input-block-level" data-bind="value: temp_sensor_address">
-          <span class="help-inline">Sensor address in HEX value, you can find it by runing
+          <span class="help-inline">Sensor address in HEX value, you can find it by running
             <code>i2cdetect -y 1</code> on your Raspberry Pi</span>
         </div>
       </div>
@@ -636,14 +637,14 @@
             <span class="label label-info">Info:</span> PRINTER actions when a condition is met, that can be a filament sensor, button, etc. Actions can
             be Pause \ Resume \ Cancel a printer_control job, change the filament or disable Temperature Control. You can
             use the "change filament" action and set up the input GPIO acording to your sensor, for example, if your filament
-            sensor conects to ground when detects the end of the filament, you should choose PULL UP resistors and detect
+            sensor connects to ground when detects the end of the filament, you should choose PULL UP resistors and detect
             the event on the falling edge.</span>
           <!-- /ko -->
           <!-- ko if: ($data.action_type() == "output_control")  -->
           <span class="help-inline">
             <span class="label label-info">Info:</span> Action will control GPIO outputs when a condition is met, for example detect a press of a button.
             You can use this to control any previous configured OUTPUTS, basically beeing able to control your lights / fan
-            / pritner using mechanical buttons buttons instead of the octoprint interface. You can only control REGULAR outputs.
+            / printer using mechanical buttons buttons instead of the octoprint interface. You can only control REGULAR outputs.
           </span>
           <!-- /ko -->
         </div>
@@ -658,7 +659,7 @@
           <input type="text" class="input-block-level" data-bind="value: gpio_pin">
           <span class="help-inline">Input GPIO that will detect the event that should trigger the action. For example if you have a filament sensor
             you put the GPIO pin that the sensor is connected. This can also be a press of a button or any other signal that
-            you want to detect. You can not use GPIO 4 here if you are using temeprature sensor DS18B20</span>
+            you want to detect. You can not use GPIO 4 here if you are using temperature sensor DS18B20</span>
         </div>
       </div>
       <div class="control-group">

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ plugin_url = "https://github.com/vitormhenrique/OctoPrint-Enclosure"
 plugin_license = "AGPLv3"
 
 # Any additional requirements besides OctoPrint should be listed here
-plugin_requires = ["RPi.GPIO>=0.6","requests>=2.7"]
+plugin_requires = ["RPi.GPIO>=0.6.5","requests>=2.7"]
 
 additional_setup_parameters = {}
 


### PR DESCRIPTION
PR attempts to fix:

- PWM not working (fixed #226)
- Debug messages not showing when using logging plugin to set log level (#227)
   - temperature and humidity still need to be set manually in enclosure setting page
- Spelling errors: fixed a plethora of spelling mistakes in strings, comments and variable names.
- added more debug messages to aid in debugging GPIO actions.

apologies for the mess of commits, I was testing via github to install on my octopi. Also pycharm "fixed" a lot of the code to PEP8 standards, so some formatting has gone from the code.