### PR TITLE
added MCP9808 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ The response will either have YES or NO at the end of the first line. If it is y
 
 Copy the serial number, you will need to configure the plugin.  Note that for the serial number includes the 28-, for example 28-0000069834ff.
 
-* For the SI7021, BME280 and TMP102 sensors
+* For the SI7021, BME280, TMP102 and MCP9808 sensors
 
 Enable I2C on your raspberry pi, depending on raspi-config version, step by step can be different:
 

--- a/octoprint_enclosure/__init__.py
+++ b/octoprint_enclosure/__init__.py
@@ -512,6 +512,9 @@ class EnclosurePlugin(octoprint.plugin.StartupPlugin, octoprint.plugin.TemplateP
                 elif sensor['temp_sensor_type'] == "max31855":
                     temp = self.read_max31855_temp(sensor['temp_sensor_address'])
                     hum = 0
+                elif sensor['temp_sensor_type'] == "mcp9808":
+                    temp = self.read_mcp_temp()
+                    hum = 0
                 else:
                     self._logger.info("temp_sensor_type no match")
                     temp = None
@@ -555,6 +558,22 @@ class EnclosurePlugin(octoprint.plugin.StartupPlugin, octoprint.plugin.TemplateP
         self.dummy_value = return_value
 
         return return_value, return_value
+
+    def read_mcp_temp(self):
+        try:
+            script = os.path.dirname(os.path.realpath(__file__)) + "/mcp9808.py"
+            args = ["python", script]
+            if self._settings.get(["debug_temperature_log"]) is True:
+                self._logger.debug("Temperature MCP9808 cmd: %s", " ".join(args))
+            proc = Popen(args, stdout=PIPE)
+            stdout, _ = proc.communicate()
+            if self._settings.get(["debug_temperature_log"]) is True:
+                self._logger.debug("MCP9808 result: %s", stdout)
+            return self.to_float(stdout.strip())
+        except Exception as ex:
+            self._logger.info("Failed to execute python scripts, try disabling use SUDO on advanced section.")
+            self.log_error(ex)
+            return 0
 
     def read_dht_temp(self, sensor, pin):
         try:

--- a/octoprint_enclosure/__init__.py
+++ b/octoprint_enclosure/__init__.py
@@ -513,7 +513,7 @@ class EnclosurePlugin(octoprint.plugin.StartupPlugin, octoprint.plugin.TemplateP
                     temp = self.read_max31855_temp(sensor['temp_sensor_address'])
                     hum = 0
                 elif sensor['temp_sensor_type'] == "mcp9808":
-                    temp = self.read_mcp_temp()
+                    temp = self.read_mcp_temp(sensor['temp_sensor_address'])
                     hum = 0
                 else:
                     self._logger.info("temp_sensor_type no match")
@@ -559,10 +559,10 @@ class EnclosurePlugin(octoprint.plugin.StartupPlugin, octoprint.plugin.TemplateP
 
         return return_value, return_value
 
-    def read_mcp_temp(self):
+    def read_mcp_temp(self, address):
         try:
             script = os.path.dirname(os.path.realpath(__file__)) + "/mcp9808.py"
-            args = ["python", script]
+            args = ["python", script, str(address)]
             if self._settings.get(["debug_temperature_log"]) is True:
                 self._logger.debug("Temperature MCP9808 cmd: %s", " ".join(args))
             proc = Popen(args, stdout=PIPE)

--- a/octoprint_enclosure/mcp9808.py
+++ b/octoprint_enclosure/mcp9808.py
@@ -1,3 +1,4 @@
+import sys
 import smbus
 
 # default I2C address for device.
@@ -27,24 +28,29 @@ MCP9808_REG_CONFIG_ALERTMODE = 0x0001
 
 
 def main():
+	# get bus address if provided or use default address
+	address = MCP9808_I2CADDR_DEFAULT
+	if len(sys.argv) == 2:
+		address = int(sys.argv[1], 16)
+
 	# get I2C bus
 	bus = smbus.SMBus(1)
 
-	# MCP9808 address, 0x18(24)
+	# MCP9808 address, default 0x18(24)
 	# configuration register, 0x01(1)
 	# continuous conversion mode, power-up default
 	config = [MCP9808_REG_CONFIG_CONTCONV, 0x00]
-	bus.write_i2c_block_data(MCP9808_I2CADDR_DEFAULT, MCP9808_REG_CONFIG, config)
+	bus.write_i2c_block_data(address, MCP9808_REG_CONFIG, config)
 
-	# MCP9808 address, 0x18(24)
+	# MCP9808 address, default 0x18(24)
 	# select resolution rgister, 0x08(8)
 	# resolution = +0.0625 / C, 0x03(03)
-	bus.write_byte_data(MCP9808_I2CADDR_DEFAULT, MCP9808_REG_RESOLUTION, 0x03)
+	bus.write_byte_data(address, MCP9808_REG_RESOLUTION, 0x03)
 
-	# MCP9808 address, 0x18(24)
+	# MCP9808 address, default 0x18(24)
 	# read data back from 0x05(5), 2 bytes
 	# temp MSB, TEMP LSB
-	data = bus.read_i2c_block_data(MCP9808_I2CADDR_DEFAULT, MCP9808_REG_AMBIENT_TEMP, 2)
+	data = bus.read_i2c_block_data(address, MCP9808_REG_AMBIENT_TEMP, 2)
 
 	# convert the data to 13-bits
 	ctemp = ((data[0] & 0x1F) * 256) + data[1]

--- a/octoprint_enclosure/mcp9808.py
+++ b/octoprint_enclosure/mcp9808.py
@@ -1,0 +1,61 @@
+import smbus
+
+# default I2C address for device.
+MCP9808_I2CADDR_DEFAULT = 0x18
+
+# register addresses.
+MCP9808_REG_CONFIG = 0x01
+MCP9808_REG_UPPER_TEMP = 0x02
+MCP9808_REG_LOWER_TEMP = 0x03
+MCP9808_REG_CRIT_TEMP = 0x04
+MCP9808_REG_AMBIENT_TEMP = 0x05
+MCP9808_REG_MANUF_ID = 0x06
+MCP9808_REG_DEVICE_ID = 0x07
+MCP9808_REG_RESOLUTION = 0x08
+
+# configuration register values.
+MCP9808_REG_CONFIG_CONTCONV = 0x0000
+MCP9808_REG_CONFIG_SHUTDOWN = 0x0100
+MCP9808_REG_CONFIG_CRITLOCKED = 0x0080
+MCP9808_REG_CONFIG_WINLOCKED = 0x0040
+MCP9808_REG_CONFIG_INTCLR = 0x0020
+MCP9808_REG_CONFIG_ALERTSTAT = 0x0010
+MCP9808_REG_CONFIG_ALERTCTRL = 0x0008
+MCP9808_REG_CONFIG_ALERTSEL = 0x0002
+MCP9808_REG_CONFIG_ALERTPOL = 0x0002
+MCP9808_REG_CONFIG_ALERTMODE = 0x0001
+
+
+def main():
+	# get I2C bus
+	bus = smbus.SMBus(1)
+
+	# MCP9808 address, 0x18(24)
+	# configuration register, 0x01(1)
+	# continuous conversion mode, power-up default
+	config = [MCP9808_REG_CONFIG_CONTCONV, 0x00]
+	bus.write_i2c_block_data(MCP9808_I2CADDR_DEFAULT, MCP9808_REG_CONFIG, config)
+
+	# MCP9808 address, 0x18(24)
+	# select resolution rgister, 0x08(8)
+	# resolution = +0.0625 / C, 0x03(03)
+	bus.write_byte_data(MCP9808_I2CADDR_DEFAULT, MCP9808_REG_RESOLUTION, 0x03)
+
+	# MCP9808 address, 0x18(24)
+	# read data back from 0x05(5), 2 bytes
+	# temp MSB, TEMP LSB
+	data = bus.read_i2c_block_data(MCP9808_I2CADDR_DEFAULT, MCP9808_REG_AMBIENT_TEMP, 2)
+
+	# convert the data to 13-bits
+	ctemp = ((data[0] & 0x1F) * 256) + data[1]
+	if ctemp > 4095:
+		ctemp -= 8192
+	ctemp = ctemp * 0.0625
+	# ftemp = ctemp * 1.8 + 32
+
+	# output data
+	print('{0:0.2f}'.format(ctemp))
+
+
+if __name__ == "__main__":
+	main()

--- a/octoprint_enclosure/templates/enclosure_settings.jinja2
+++ b/octoprint_enclosure/templates/enclosure_settings.jinja2
@@ -538,6 +538,7 @@
             <option value="bme280">BME280</option>
             <option value="tmp102">TMP102</option>
             <option value="max31855">MAX31855</option>
+            <option value="mcp9808">MCP9808</option>
           </select>
           <span class="help-inline">
             <span class="label label-important">Attention</span> You need to install and configure the necessary libraries for the temperature sensor, check
@@ -562,7 +563,7 @@
         </div>
       </div>
       <!-- /ko -->
-      <!-- ko if: ($data.temp_sensor_type() == "si7021") || ($data.temp_sensor_type() == "bme280") || ($data.temp_sensor_type() == "tmp102") -->
+      <!-- ko if: ($data.temp_sensor_type() == "si7021") || ($data.temp_sensor_type() == "bme280") || ($data.temp_sensor_type() == "tmp102") || ($data.temp_sensor_type() == "mcp9808") -->
       <div class="control-group">
         <label class="control-label" for="settings-enclosure-dhtPin">{{ _('Sensor Pin') }}</label>
         <div class="controls">
@@ -604,7 +605,7 @@
       </div>
       
       <!-- /ko -->
-      <!-- ko ifnot: ($data.temp_sensor_type() == "18b20") || ($data.temp_sensor_type() == "si7021") || ($data.temp_sensor_type() == "bme280") || ($data.temp_sensor_type() == "tmp102") || ($data.temp_sensor_type() == "max31855") -->
+      <!-- ko ifnot: ($data.temp_sensor_type() == "18b20") || ($data.temp_sensor_type() == "si7021") || ($data.temp_sensor_type() == "bme280") || ($data.temp_sensor_type() == "tmp102") || ($data.temp_sensor_type() == "max31855") || ($data.temp_sensor_type() == "mcp9808") -->
       <div class="control-group">
         <label class="control-label" for="settings-enclosure-dhtPin">{{ _('Sensor Pin') }}</label>
         <div class="controls">

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_enclosure"
 plugin_name = "OctoPrint-Enclosure"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "4.12"
+plugin_version = "4.13"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module


### PR DESCRIPTION
added support for the [Adafruit MCP9808](https://learn.adafruit.com/adafruit-mcp9808-precision-i2c-temperature-sensor-guide)

only the smbus python library and enabling I2C is needed

also solves issue #211