### PR TITLE
Update API temperature values

### DIFF
--- a/octoprint_enclosure/__init__.py
+++ b/octoprint_enclosure/__init__.py
@@ -637,6 +637,8 @@ class EnclosurePlugin(octoprint.plugin.StartupPlugin, octoprint.plugin.TemplateP
                 if  self._settings.get(["debug_temperature_log"]) is True:
                     self._logger.debug("Sensor %s Temperature: %s humidity %s", sensor['label'], temp, hum)
                 if temp is not None and hum is not None:
+                    sensor["temp_sensor_temp"] = temp
+                    sensor["temp_sensor_humidity"] = hum
                     sensor_data.append(dict(index_id=sensor['index_id'], temperature=temp, humidity=hum))
                     self.temperature_sensor_data = sensor_data
                     self.handle_temp_hum_control()

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_enclosure"
 plugin_name = "OctoPrint-Enclosure"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "4.13"
+plugin_version = "4.13.1"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module


### PR DESCRIPTION
Hi,

I noticed some funky behaviour with the new API (#261 ). Basically the temperature shown in the WebUI differs from the one returned from the API.

 After some digging I found, that the rpi_inputs aren't updated when the temperature is read. These 2 simple lines of codes update the rpi_inputs array (python makes shallow copies by default, which means the original object is updated). 

I did test this with some absurd hardcoded values and they were returned correctly by the API. Hope you can merge this as well, as this will make the API way more useful :)