### PR TITLE
adds python 3.7 compatibility

### DIFF
--- a/octoprint_enclosure/__init__.py
+++ b/octoprint_enclosure/__init__.py
@@ -1857,6 +1857,7 @@ class EnclosurePlugin(octoprint.plugin.StartupPlugin, octoprint.plugin.TemplateP
 
 
 __plugin_name__ = "Enclosure Plugin"
+__plugin_pythoncompat__ = ">=2.7,<4"
 
 
 def __plugin_load__():


### PR DESCRIPTION
I upgraded to Python 3.7 and I could not run your plug-in. 

I got the following error: "Plugin Enclosure Plugin (4.13.1) is not compatible to Python 3.7.3 (compatibility string: >=2.7,<3)." But it does install fine with Python 3.7.

So I added just one line and it seems to work fine for me. I just use the DS18B20 as Temperature Sensor and I didn't test other features because I don't need them. But I don't get any issue or error with it by running Python 3.7. Hope that solves the issues of others that are upgrading to Python 3.7.