### PR TITLE
Brightness control for WS28B12 (Neopixel) fixed

### DIFF
--- a/octoprint_enclosure/neopixel_direct.py
+++ b/octoprint_enclosure/neopixel_direct.py
@@ -17,7 +17,7 @@ else:
     print("fail")
     sys.exit(1)
 
-strip = Adafruit_NeoPixel(LED_COUNT, LED_PIN, LED_FREQ_HZ, LED_DMA, LED_INVERT)
+strip = Adafruit_NeoPixel(LED_COUNT, LED_PIN, LED_FREQ_HZ, LED_DMA, LED_INVERT, LED_BRIGHTNESS)
 strip.begin()
 
 color = Color(red, green, blue)


### PR DESCRIPTION
Hi
I've faced the problem of changing the meaning of the parameter "Brightness", cause there is no effect of plugin in settings.
But then I've understood that `LED_BRIGHTNESS` parameter is not used in the file `neopxel_direct.py`
Only after adding this parameter into the constructor light brightness changing has begun to work. 

I've also made an issue [here](https://github.com/vitormhenrique/OctoPrint-Enclosure/issues/311).
Please close the issue when you merge.
Thanks.