### PR TITLE
Convert STDOUT from Popen's to UTF-8

### DIFF
--- a/octoprint_enclosure/__init__.py
+++ b/octoprint_enclosure/__init__.py
@@ -864,7 +864,7 @@ class EnclosurePlugin(octoprint.plugin.StartupPlugin, octoprint.plugin.TemplateP
             stdout, _ = proc.communicate()
             if self._settings.get(["debug_temperature_log"]) is True:
                 self._logger.debug("MCP9808 result: %s", stdout)
-            return self.to_float(stdout.strip())
+            return self.to_float(stdout.decode("utf-8").strip())
         except Exception as ex:
             self._logger.info("Failed to execute python scripts, try disabling use SUDO on advanced section.")
             self.log_error(ex)
@@ -883,7 +883,7 @@ class EnclosurePlugin(octoprint.plugin.StartupPlugin, octoprint.plugin.TemplateP
             stdout = (Popen(cmd, shell=True, stdout=PIPE).stdout).read()
             if  self._settings.get(["debug_temperature_log"]) is True:
                 self._logger.debug("Dht result: %s", stdout)
-            temp, hum = stdout.split("|")
+            temp, hum = stdout.decode("utf-8").split("|")
             return (self.to_float(temp.strip()), self.to_float(hum.strip()))
         except Exception as ex:
             self._logger.info(
@@ -904,7 +904,7 @@ class EnclosurePlugin(octoprint.plugin.StartupPlugin, octoprint.plugin.TemplateP
             stdout = (Popen(cmd, shell=True, stdout=PIPE).stdout).read()
             if  self._settings.get(["debug_temperature_log"]) is True:
                 self._logger.debug("BME280 result: %s", stdout)
-            temp, hum = stdout.split("|")
+            temp, hum = stdout.decode("utf-8").split("|")
             return (self.to_float(temp.strip()), self.to_float(hum.strip()))
         except Exception as ex:
             self._logger.info(
@@ -925,7 +925,7 @@ class EnclosurePlugin(octoprint.plugin.StartupPlugin, octoprint.plugin.TemplateP
             stdout = (Popen(cmd, shell=True, stdout=PIPE).stdout).read()
             if  self._settings.get(["debug_temperature_log"]) is True:
                 self._logger.debug("AM2320 result: %s", stdout)
-            temp, hum = stdout.split("|")
+            temp, hum = stdout.decode("utf-8").split("|")
             return (self.to_float(temp.strip()), self.to_float(hum.strip()))
         except Exception as ex:
             self._logger.info(
@@ -946,7 +946,7 @@ class EnclosurePlugin(octoprint.plugin.StartupPlugin, octoprint.plugin.TemplateP
             stdout = (Popen(cmd, shell=True, stdout=PIPE).stdout).read()
             if  self._settings.get(["debug_temperature_log"]) is True:
                 self._logger.debug("SI7021 result: %s", stdout)
-            temp, hum = stdout.split("|")
+            temp, hum = stdout.decode("utf-8").split("|")
             return (self.to_float(temp.strip()), self.to_float(hum.strip()))
         except Exception as ex:
             self._logger.info(
@@ -990,7 +990,7 @@ class EnclosurePlugin(octoprint.plugin.StartupPlugin, octoprint.plugin.TemplateP
             stdout, _ = proc.communicate()
             if  self._settings.get(["debug_temperature_log"]) is True:
                 self._logger.debug("TMP102 result: %s", stdout)
-            return self.to_float(stdout.strip())
+            return self.to_float(stdout.decode("utf-8").strip())
         except Exception as ex:
             self._logger.info("Failed to execute python scripts, try disabling use SUDO on advanced section.")
             self.log_error(ex)
@@ -1006,7 +1006,7 @@ class EnclosurePlugin(octoprint.plugin.StartupPlugin, octoprint.plugin.TemplateP
             stdout, _ = proc.communicate()
             if  self._settings.get(["debug_temperature_log"]) is True:
                 self._logger.debug("MAX31855 result: %s", stdout)
-            return self.to_float(stdout.strip())
+            return self.to_float(stdout.decode("utf-8").strip())
         except Exception as ex:
             self._logger.info("Failed to execute python scripts, try disabling use SUDO on advanced section.")
             self.log_error(ex)


### PR DESCRIPTION
By default, Python3's STDOUT's that come back from Popen commands
are byte-arrays, not strings.  So attempting to do string operations
(like 'split' or 'strip') fail.  They must be converted to UTF-8
strings first.

This was causing the enclosure plugin to return false debug messages about
'disabling SUDO' when attempting to read my DHT22 sensor.