### PR TITLE
Implemented temperature and humidity display in graph

### DIFF
--- a/octoprint_enclosure/__init__.py
+++ b/octoprint_enclosure/__init__.py
@@ -148,7 +148,7 @@ class EnclosurePlugin(octoprint.plugin.StartupPlugin, octoprint.plugin.TemplateP
         self.print_complete = False
 
     def get_settings_version(self):
-        return 6
+        return 7
 
     def on_settings_migrate(self, target, current=None):
         self._logger.warn("######### current settings version %s target settings version %s #########", current, target)
@@ -157,14 +157,25 @@ class EnclosurePlugin(octoprint.plugin.StartupPlugin, octoprint.plugin.TemplateP
         self._logger.info("rpi_inputs: %s", self.rpi_inputs)
         self._logger.info("#########        End Current Settings        #########")
         if current >= 4 and target == 6:
-            self._logger.warn("######### migrating settings to v6 #########")
             old_outputs = self._settings.get(["rpi_outputs"])
+            old_inputs = self._settings.get(["rpi_inputs"])
+            self._logger.warn("######### migrating settings to v6+ #########")
             for rpi_output in old_outputs:
                 if 'shutdown_on_failed' not in rpi_output:
                     rpi_output['shutdown_on_failed'] = False
                 if 'shell_script' not in rpi_output:
                     rpi_output['shell_script'] = ""
+
+            if target >= 7:
+                self._logger.warn("######### migrating settings to v7+ #########")
+                for rpi_input in old_inputs:
+                    if 'show_graph_temp' not in rpi_input:
+                        rpi_input['show_graph_temp'] = False
+                    if 'show_graph_humidity' not in rpi_input:
+                        rpi_input['show_graph_humidity'] = False
+
             self._settings.set(["rpi_outputs"], old_outputs)
+            self._settings.set(["rpi_inputs"], old_inputs)
         else:
             self._logger.warn("######### settings not compatible #########")
             self._settings.set(["rpi_outputs"], [])
@@ -1944,6 +1955,15 @@ class EnclosurePlugin(octoprint.plugin.StartupPlugin, octoprint.plugin.TemplateP
                     comm_instance._log("Setting TEMP/HUM control output %s to value %s" % (index_id, set_value))
                     return
 
+    def get_graph_data(self, comm, parsed_temps):
+        for sensor in list(filter(lambda item: item['input_type'] == 'temperature_sensor', self.rpi_inputs)):
+            if sensor["show_graph_temp"]:
+                parsed_temps[str(sensor["label"])] = (sensor['temp_sensor_temp'], None)
+            if sensor["show_graph_humidity"]:
+                parsed_temps[str(sensor["label"])+" Humidity"] = (sensor['temp_sensor_humidity'], None)
+
+        return parsed_temps
+
 
 __plugin_name__ = "Enclosure Plugin"
 __plugin_pythoncompat__ = ">=2.7,<4"
@@ -1956,5 +1976,6 @@ def __plugin_load__():
     global __plugin_hooks__
     __plugin_hooks__ = {
         "octoprint.comm.protocol.gcode.queuing"       : __plugin_implementation__.hook_gcode_queuing,
-        "octoprint.plugin.softwareupdate.check_config": __plugin_implementation__.get_update_information
+        "octoprint.plugin.softwareupdate.check_config": __plugin_implementation__.get_update_information,
+        "octoprint.comm.protocol.temperatures.received": (__plugin_implementation__.get_graph_data, 1)
     }

--- a/octoprint_enclosure/static/js/enclosure.js
+++ b/octoprint_enclosure/static/js/enclosure.js
@@ -456,7 +456,9 @@ $(function () {
         temp_sensor_navbar: ko.observable(true),
         filament_sensor_timeout: ko.observable(120),
         filament_sensor_enabled: ko.observable(true),
-        temp_sensor_i2cbus: ko.observable(1)
+        temp_sensor_i2cbus: ko.observable(1),
+        show_graph_temp: ko.observable(false),
+        show_graph_humidity: ko.observable(false)
       });
     };
 

--- a/octoprint_enclosure/templates/enclosure_settings.jinja2
+++ b/octoprint_enclosure/templates/enclosure_settings.jinja2
@@ -765,6 +765,24 @@
         </label>
         <span class="help-inline">Enable and disable temperature on navbar</span>
       </div>
+      <div class="controls">
+		    <label class="checkbox">
+				  <input type="checkbox" data-bind="checked: show_graph_temp"> {{ _('Show temperature in graph') }}
+			  </label>
+			  <span class="help-inline">Enable to show temperature in temperature graph, when a printer is connected.
+        <!-- ko if: ($data.show_graph_temp())  -->
+        <p><i><strong>Note:</strong>This feature currently requires a custom graph plugin like <a href="https://github.com/jneilliii/OctoPrint-PlotlyTempGraph" target="_blank">PlotlyTempGraph</a></i></span></p>
+        <!-- /ko -->
+		  </div>
+      <div class="controls">
+        <label class="checkbox">
+          <input type="checkbox" data-bind="checked: show_graph_humidity"> {{ _('Show humidity in graph') }}
+        </label>
+        <span class="help-inline">Enable to show humidity in temperature graph, when a printer is connected.
+        <!-- ko if: ($data.show_graph_humidity())  -->
+        <p><i><strong>Note:</strong>This feature currently requires a custom graph plugin like <a href="https://github.com/jneilliii/OctoPrint-PlotlyTempGraph" target="_blank">PlotlyTempGraph</a></i></span></p>
+        <!-- /ko -->
+      </div>
     </div>
     <!-- /ko -->
     <div class="control-group">


### PR DESCRIPTION
Hi, first of all great plugin!

With my changes every temperature sensor now has a "_Show temperature in graph_" and a "_Show humidity in graph_" option which allows to show these values in the temperature graph.

I added this by I implementing the ```octoprint.comm.protocol.temperatures.received```-hook and automaticaly add the temperature and humidity values to the data-set for all sensors that have these options checked.

**Remarks:**
The default graph currently does not display these custom values, yet, but it works perfectly with @jneilliii s OctoPrint-PlotlyTempGraph Plugin: https://github.com/jneilliii/OctoPrint-PlotlyTempGraph

If you enable one of the new "show in graph"-checkboxes, it also automatically displays a message, which informs the user about this (See screenshots for on/off examples).

**Testing:**
I did a fresh branch for the PR, but I have my implementation running since november, without any issues 😄 
(See my master branch https://github.com/Dak0r/OctoPrint-Enclosure-with-Custom-Graphs/commits/master ) 

**Related issues:** https://github.com/vitormhenrique/OctoPrint-Enclosure/issues/34 https://github.com/vitormhenrique/OctoPrint-Enclosure/issues/303

Again thanks to @jneilliii for his Graph plugin and helping me with getting the settings patcher going 👍 

**Graph with "Enclosure" named Temperature Sensor:**

![graph](https://user-images.githubusercontent.com/4193623/107569174-4b02ee00-6be8-11eb-9679-382ebb99a17e.png)

**Settings for the shown Temperature Sensor:**

![new setting on off](https://user-images.githubusercontent.com/4193623/107569219-59510a00-6be8-11eb-9da0-b9396e9e1ed9.png)