### PR TITLE
Change read_raw_i2c_temp to return temp and humidity

### DIFF
--- a/octoprint_enclosure/__init__.py
+++ b/octoprint_enclosure/__init__.py
@@ -1054,9 +1054,13 @@ class EnclosurePlugin(octoprint.plugin.StartupPlugin, octoprint.plugin.TemplateP
                 data = bus.read_i2c_block_data(i2caddr, i2creg, 8)
                 val = struct.unpack('f', bytearray(data[0:4]))
                 fval1 = val[0]
+                if fval1 != fval1:
+                    fval1 = 0
                 val = struct.unpack('f', bytearray(data[4:8]))
                 fval2 = val[0]
-
+                if fval2 != fval2:
+                    fval2 = 0
+                
                 self._logger.debug("read_raw_i2c_temp(i2cbus=%s, i2caddr=%s, i2creg=%s) data == %s (%s, %s)",
                                     i2cbus, i2caddr, i2creg, data, fval1, fval2)
 

--- a/octoprint_enclosure/__init__.py
+++ b/octoprint_enclosure/__init__.py
@@ -1052,12 +1052,10 @@ class EnclosurePlugin(octoprint.plugin.StartupPlugin, octoprint.plugin.TemplateP
 
             with SMBus(i2cbus) as bus:
                 data = bus.read_i2c_block_data(i2caddr, i2creg, 8)
-                val = struct.unpack('f', bytearray(data[0:4]))
-                fval1 = val[0]
+                fval1 = struct.unpack('f', bytearray(data[0:4]))[0]
                 if fval1 != fval1:
                     fval1 = 0
-                val = struct.unpack('f', bytearray(data[4:8]))
-                fval2 = val[0]
+                fval2 = struct.unpack('f', bytearray(data[4:8]))[0]
                 if fval2 != fval2:
                     fval2 = 0
                 

--- a/octoprint_enclosure/__init__.py
+++ b/octoprint_enclosure/__init__.py
@@ -993,11 +993,9 @@ class EnclosurePlugin(octoprint.plugin.StartupPlugin, octoprint.plugin.TemplateP
                     temp = self.read_mcp_temp(sensor['temp_sensor_address'])
                     hum = 0
                 elif sensor['temp_sensor_type'] == "temp_raw_i2c":
-                    temp = self.read_raw_i2c_temp(sensor)
-                    hum = 0
+                    temp, hum = self.read_raw_i2c_temp(sensor)
                 elif sensor['temp_sensor_type'] == "hum_raw_i2c":
-                    temp = 0
-                    hum = self.read_raw_i2c_temp(sensor)
+                    hum, temp = self.read_raw_i2c_temp(sensor)
                 else:
                     self._logger.info("temp_sensor_type no match")
                     temp = None
@@ -1053,14 +1051,16 @@ class EnclosurePlugin(octoprint.plugin.StartupPlugin, octoprint.plugin.TemplateP
             i2creg = self.to_int(sensor['temp_i2c_register'])
 
             with SMBus(i2cbus) as bus:
-                data = bus.read_i2c_block_data(i2caddr, i2creg, 4)
-                val = struct.unpack('f', bytearray(data))
-                fval = val[0]
+                data = bus.read_i2c_block_data(i2caddr, i2creg, 8)
+                val = struct.unpack('f', bytearray(data[0:4]))
+                fval1 = val[0]
+                val = struct.unpack('f', bytearray(data[4:8]))
+                fval2 = val[0]
 
-                self._logger.debug("read_raw_i2c_temp(i2cbus=%s, i2caddr=%s, i2creg=%s) data == %s (%s)",
-                                    i2cbus, i2caddr, i2creg, data, fval)
+                self._logger.debug("read_raw_i2c_temp(i2cbus=%s, i2caddr=%s, i2creg=%s) data == %s (%s, %s)",
+                                    i2cbus, i2caddr, i2creg, data, fval1, fval2)
 
-                return str(fval)
+                return (fval1, fval2)
 
         except Exception as ex:
             template = "An exception of type {0} occurred on {1} when reading on i2c address {2}, reg {3}. Arguments:\n{4!r}"

--- a/octoprint_enclosure/static/js/enclosure.js
+++ b/octoprint_enclosure/static/js/enclosure.js
@@ -56,7 +56,7 @@ $(function () {
     self.notifications = ko.observableArray([]);
 
     self.humidityCapableSensor = function(sensor){
-      if (['11', '22', '2302', 'bme280', 'am2320', 'si7021'].indexOf(sensor) >= 0){
+      if (['11', '22', '2302', 'bme280', 'am2320', 'si7021', 'hum_raw_i2c', 'temp_raw_i2c'].indexOf(sensor) >= 0){
         return true;
       }
       return false;


### PR DESCRIPTION
Change read_raw_i2c_temp to read one or two float values from slave; one for temperature and the other for humidity.

Modified get_sensor_data to populate temp & hum based on the sensor type:

- When the sensor type is "temp_raw_i2c" the resulting assignment is temp followed by hum.

- When the sensor type is "hum_raw_i2c" the resulting assignment is hum followed by temp.

Added hum_raw_i2c and temp_raw_i2c to list of humdityCapableSensor's.

Arduino code for sending two float values:
```
    float data[2];
    data[0] = (float) t1; // Temp
    data[1] = (float) h1; // Humidity
    Wire.write((uint8_t*) data, sizeof(data));
```
Arduino code for sending a single float value:
```
    float data[1];
    data[0] = (float) t1; // Temp
    Wire.write((uint8_t*) data, sizeof(data));
```
or
```
union floatBytes
{
  uint8_t bytes[4];
  float value;
} floatContainer;

    floatContainer.value = t1;
    Wire.write(floatContainer.bytes, sizeof(float));

```
