### PR TITLE
Add option for pullup for DS18B20

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Note that the first argument is the temperature sensor (11, 22, or 2302), and th
 
 * For the DS18B20 sensor:
 
-Follow the wiring diagram on the pictures on thingiverse. The DS18B20 uses "1-wire" communication protocol, you need to use 4.7K to 10K resistor from the data pin to VCC, DS18B20 only works on GPIO pin number 4 by default. You also need to add OneWire support for your raspberry pi.
+Follow the wiring diagram on the pictures on thingiverse. The DS18B20 uses "1-wire" communication protocol, DS18B20 only works on GPIO pin number 4 by default. You also need to add OneWire support for your raspberry pi.
 
 Start by adding the following line to /boot/config.txt
 
@@ -75,6 +75,16 @@ After rebooting, you can check if the OneWire device was found properly with
 <pre><code>dmesg | grep w1-gpio</code></pre>
 You should see something like
 <pre><code>[    3.030368] w1-gpio onewire@0: gpio pin 4, external pullup pin -1, parasitic power 0</code></pre>
+
+If you're using the internal pullup resistor, you'll need to enable it manually by running these Python commands. Or, you can simply configure the sensor inside of the Enclosure plugin, which will do this for you.
+
+```python
+import RPi.GPIO as GPIO
+
+PIN=4
+GPIO.setmode(GPIO.BCM)
+GPIO.setup(PIN, GPIO.IN, pull_up_down=GPIO.PUD_UP)
+```
 
 You should be able to test your sensor by rebooting your system with sudo reboot. When the Pi is back up and you're logged in again, type the commands you see below into a terminal window. When you are in the 'devices' directory, the directory starting '28-' may have a different name, so cd to the name of whatever directory is there.
 
@@ -88,6 +98,8 @@ cat w1_slave</code></pre>
 The response will either have YES or NO at the end of the first line. If it is yes, then the temperature will be at the end of the second line, in 1/000 degrees C.
 
 Copy the serial number, you will need to configure the plugin.  Note that for the serial number includes the 28-, for example 28-0000069834ff.
+
+The DS18B20 needs a pullup resistor on the data pin. On modern Pi models, you can use a resistor built into the Pi, configured in software. To do this, set the "Input Pull Resistor" option to "Input Pullup". If this doesn't work, you need to use a 4.7K to 10K resistor from the data pin to VCC.
 
 * For the SI7021, BME280, TMP102 and MCP9808 sensors
 

--- a/octoprint_enclosure/__init__.py
+++ b/octoprint_enclosure/__init__.py
@@ -1348,7 +1348,7 @@ class EnclosurePlugin(octoprint.plugin.StartupPlugin, octoprint.plugin.TemplateP
     def log_error(self, ex):
         template = "An exception of type {0} occurred on {1}. Arguments:\n{2!r}"
         message = template.format(type(ex).__name__, inspect.currentframe().f_code.co_name, ex.args)
-        self._logger.warn(message)
+        self._logger.warn(message, exc_info = True)
 
     def setup_gpio(self):
         try:
@@ -1461,6 +1461,16 @@ class EnclosurePlugin(octoprint.plugin.StartupPlugin, octoprint.plugin.TemplateP
                 if (rpi_input['action_type'] == 'printer_control' and rpi_input['printer_action'] != 'filament'):
                     GPIO.add_event_detect(gpio_pin, edge, callback=self.handle_printer_action, bouncetime=200)
                     self._logger.info("Adding PRINTER CONTROL event detect on pin %s with edge: %s", gpio_pin, edge)
+            
+            for rpi_input in list(filter(lambda item: item['input_type'] == 'temperature_sensor', self.rpi_inputs)):
+                gpio_pin = self.to_int(rpi_input['gpio_pin'])
+                if rpi_input['input_pull_resistor'] == 'input_pull_up':
+                    pull_resistor = GPIO.PUD_UP
+                elif rpi_input['input_pull_resistor'] == 'input_pull_down':
+                    pull_resistor = GPIO.PUD_DOWN
+                else:
+                    pull_resistor = GPIO.PUD_OFF
+                GPIO.setup(gpio_pin, GPIO.IN, pull_up_down=pull_resistor)
         except Exception as ex:
             self.log_error(ex)
 

--- a/octoprint_enclosure/templates/enclosure_settings.jinja2
+++ b/octoprint_enclosure/templates/enclosure_settings.jinja2
@@ -649,6 +649,16 @@
           <span class="help-inline">GPIO pin for temperature sensor, recommended to use 4 as DS18B20 has default support to pin #4 (BCM)</span>
         </div>
       </div>
+      <div class"control-group">
+        <label class="control-label" for="settings-enclosure-dhtPin">{{ _('Input Pull Resistor') }}</label>
+        <div class="controls">
+          <select data-bind="value: input_pull_resistor">
+            <option value="" selected="selected">None</option>
+            <option value="input_pull_up">Input Pullup</option>
+          </select>
+          <span class="help-inline">Whether to enable the built-in pullup for this temperature sensor. If set, then no external pullup is needed.</span>
+        </div>
+      </div>
       <div class="control-group">
         <label class="control-label" for="settings-enclosure-dhtPin">{{ _('DS18B20 Serial') }}</label>
         <div class="controls">


### PR DESCRIPTION
These sensors need a pullup resistor on the data pin. Instead of using
an external pullup, this adds an option to use an internal pullup.

See [these instructions](https://blog.robertelder.org/ds18b20-raspberry-pi-setup-pullup/) for more details.