### PR TITLE
Changed README.md to new Adafruit_DHT library

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,32 +45,23 @@ To control the enclosure temperature or get temperature triggered events, you ne
 
 #### DHT11, DHT22 and AM2302 sensors
 
-Wire the sensor following the wiring diagram on the pictures on thingiverse, you can use any GPIO pin.
+Wire the sensor following the wiring diagram on the pictures on thingiverse; you can use any GPIO pin.
 
 For DHT11 and DHT22 sensors, don't forget to connect a 4.7K - 10K resistor from the data pin to VCC. Also, be aware that DHT sensors some times can not work reliably on linux, this is a limitation of reading DHT sensors from Linux--there's no guarantee the program will be given enough priority and time by the Linux kernel to reliably read the sensor. Another common issue is the power supply. you need a constant and good 3.3V, sometimes a underpowered raspberry pi will not have a solid 3.3V power supply, so you could try powering the sensor with 5V and using a level shifter on the read pin.
 
-You need to install Adafruit library to use the temperature sensor on raspberry pi.
+You need to install the Adafruit library to use the temperature sensor on Raspberry Pi. Recent versions of this plugin have moved to supporting the CircuitPython-based library on Python3 installed below.
 
 Open a raspberry pi terminal and type:
 
 ```
-cd ~
-git clone https://github.com/adafruit/Adafruit_Python_DHT.git
-cd Adafruit_Python_DHT
+pip3 install adafruit-circuitpython-dht
 sudo apt-get update
-sudo apt-get install build-essential python-dev python-openssl
-sudo python setup.py install
+sudo apt-get install libgpiod2 -y
 ```
 
-Note: All libraries need to be installed on raspberry pi system python not octoprint virtual environment.
+This will install all requirements of the library.
 
-You can test the library by using:
-
-```
-cd examples
-sudo ./AdafruitDHT.py 2302 4</code></pre>
-```
-Note that the first argument is the temperature sensor (11, 22, or 2302), and the second argument is the GPIO  that the sensor was connected.
+You can test the library by using the sample code from https://learn.adafruit.com/dht-humidity-sensing-on-raspberry-pi-with-gdocs-logging/python-setup.
 
 #### DS18B20 sensor
 


### PR DESCRIPTION
The library used has changed, but the instructions were never updated to explain how to install the new library. This corrects that oversight.