### PR TITLE
Retry when DHT temp sensor read fails

### DIFF
--- a/octoprint_enclosure/getDHTTemp.py
+++ b/octoprint_enclosure/getDHTTemp.py
@@ -1,9 +1,10 @@
 import sys
+import time
 import adafruit_dht
 
 
 # Parse command line parameters.
-sensor_args =   {   
+sensor_args =   {
                     '11': adafruit_dht.DHT11,
                     '22': adafruit_dht.DHT22,
                     '2302': adafruit_dht.DHT22
@@ -16,12 +17,29 @@ else:
     sys.exit(1)
 
 dht_dev = sensor(pin)
-humidity = dht_dev.humidity
-temperature = dht_dev.temperature
 
-if humidity is not None and temperature is not None:
-    print('{0:0.1f} | {1:0.1f}'.format(temperature, humidity))
-else:
-    print('-1 | -1')
+# DHT sensor read fails quite often, causing enclosure plugin to report value of 0.
+# If this happens, retry as suggested in the adafruit_dht docs.
+max_retries = 3
+retry_count = 0
+while retry_count <= max_retries:
+    try:
+        humidity = dht_dev.humidity
+        temperature = dht_dev.temperature
 
+        if humidity is not None and temperature is not None:
+            print('{0:0.1f} | {1:0.1f}'.format(temperature, humidity))
+            sys.exit(1)
+    except RuntimeError as e:
+        time.sleep(2)
+        retry_count += 1
+        continue
+    except Exception as e:
+        dht_dev.exit()
+        raise e
+
+    time.sleep(1)
+    retry_count += 1
+
+print('-1 | -1')
 sys.exit(1)


### PR DESCRIPTION
DHT sensor reads fail fairly often, causing the enclosure plugin to report a value of 0. When this happens, octoprint logs the exception:

```
Traceback (most recent call last):
  File "/home/pi/oprint/lib/python3.7/site-packages/octoprint_enclosure/getDHTTemp.py", line 19, in <module>
     humidity = dht_dev.humidity
  File "/home/pi/.local/lib/python3.7/site-packages/adafruit_dht.py", line 284, in humidity
     self.measure()
  File "/home/pi/.local/lib/python3.7/site-packages/adafruit_dht.py", line 230, in measure
    raise RuntimeError("A full buffer was not returned. Try again.")
RuntimeError: A full buffer was not returned. Try again.
```

This seem to be a well known issue, the adafruit_dht docs recommend catching the failed read exception and retrying.  I no longer get false 0 degree readings with this change.