### PR TITLE
Overall DHT11,22,2302 Improvments + MQTT Publishing Support

### DIFF
--- a/octoprint_enclosure/__init__.py
+++ b/octoprint_enclosure/__init__.py
@@ -77,7 +77,7 @@ class EnclosurePlugin(octoprint.plugin.StartupPlugin, octoprint.plugin.TemplateP
         # mqtt helper
         self.mqtt_publish = lambda *args, **kwargs: None
         # hardcoded
-        self.mqtt_root_topic = "Monolith/temperature/enclosure"
+        self.mqtt_root_topic = "octoprint/plugins/enclosure"
         self.mqtt_sensor_topic = self.mqtt_root_topic + "/" + "enclosure"
         self.mqtt_message = "{\"temperature\": 0, \"humidity\": 0}"
   

--- a/octoprint_enclosure/__init__.py
+++ b/octoprint_enclosure/__init__.py
@@ -74,10 +74,8 @@ class EnclosurePlugin(octoprint.plugin.StartupPlugin, octoprint.plugin.TemplateP
     dummy_delta = 0.5
     
     def __init__(self):
-        # mqtt helpers
+        # mqtt helper
         self.mqtt_publish = lambda *args, **kwargs: None
-        self.mqtt_subscribe = lambda *args, **kwargs: None
-        self.mqtt_unsubscribe = lambda *args, **kwargs: None
         # hardcoded
         self.mqtt_root_topic = "Monolith/temperature/enclosure"
         self.mqtt_sensor_topic = self.mqtt_root_topic + "/" + "enclosure"
@@ -150,15 +148,8 @@ class EnclosurePlugin(octoprint.plugin.StartupPlugin, octoprint.plugin.TemplateP
         if helpers:
             if "mqtt_publish" in helpers:
                 self.mqtt_publish = helpers["mqtt_publish"]
-            if "mqtt_subscribe" in helpers:
-                self.mqtt_subscribe = helpers["mqtt_subscribe"]
-            if "mqtt_unsubscribe" in helpers:
-                self.mqtt_unsubscribe = helpers["mqtt_unsubscribe"]
         else:
-            self._logger.info("mqtt helpers not found. mqtt functions won't work")
-        
-        # Test MQTT
-        #self.mqtt_publish(self.mqtt_sensor_topic, self.mqtt_message)
+            self._logger.info("mqtt helpers not found. mqtt functions won't work")       
         
         self.pwm_instances = []
         self.event_queue = []

--- a/octoprint_enclosure/__init__.py
+++ b/octoprint_enclosure/__init__.py
@@ -982,6 +982,7 @@ class EnclosurePlugin(octoprint.plugin.StartupPlugin, octoprint.plugin.TemplateP
             else:
                 if sensor['temp_sensor_type'] in ["11", "22", "2302"]:
                     temp, hum = self.read_dht_temp(sensor['temp_sensor_type'], sensor['gpio_pin'])
+                    airquality = 0
                 elif sensor['temp_sensor_type'] == "18b20":
                     temp = self.read_18b20_temp(sensor['ds18b20_serial'])
                     hum = 0

--- a/octoprint_enclosure/getDHTTemp.py
+++ b/octoprint_enclosure/getDHTTemp.py
@@ -1,9 +1,10 @@
 import sys
+import time
 import adafruit_dht
 
 
 # Parse command line parameters.
-sensor_args =   {   
+sensor_args =   {
                     '11': adafruit_dht.DHT11,
                     '22': adafruit_dht.DHT22,
                     '2302': adafruit_dht.DHT22
@@ -16,12 +17,29 @@ else:
     sys.exit(1)
 
 dht_dev = sensor(pin)
-humidity = dht_dev.humidity
-temperature = dht_dev.temperature
 
-if humidity is not None and temperature is not None:
-    print('{0:0.1f} | {1:0.1f}'.format(temperature, humidity))
-else:
-    print('-1 | -1')
+# DHT sensor read fails quite often, causing enclosure plugin to report value of 0.
+# If this happens, retry as suggested in the adafruit_dht docs.
+max_retries = 3
+retry_count = 0
+while retry_count <= max_retries:
+    try:
+        humidity = dht_dev.humidity
+        temperature = dht_dev.temperature
 
+        if humidity is not None and temperature is not None:
+            print('{0:0.1f} | {1:0.1f}'.format(temperature, humidity))
+            sys.exit(1)
+    except RuntimeError as e:
+        time.sleep(2)
+        retry_count += 1
+        continue
+    except Exception as e:
+        dht_dev.exit()
+        raise e
+
+    time.sleep(1)
+    retry_count += 1
+
+print('-1 | -1')
 sys.exit(1)


### PR DESCRIPTION
This is branched from @markleary's pull request that avoids bad readings. I added the DHT11,22,2302 airquality = 0 fix to make a more complete update to the way DHT readings are handled. I also began implementing MQTT Publishing Support using the MQTT Plugins Helper functions. There is currently no config for the topic ("octoprint/plugins/enclosure") but it will work out of the box as long as the MQTT plugin is installed and configured. I also tested to verify it still runs as expected without the MQTT Plugin. So adding this shouldn't break anything or force MQTT plugin to be a dependency.