### PR TITLE
Fixed implementation for BME680 sensor

### DIFF
--- a/octoprint_enclosure/BME680.py
+++ b/octoprint_enclosure/BME680.py
@@ -2,33 +2,11 @@ import bme680
 import time
 
 
-try:
-    sensor = bme680.BME680(bme680.I2C_ADDR_PRIMARY)
-except IOError:
-    sensor = bme680.BME680(bme680.I2C_ADDR_SECONDARY)
-
-hum_weighting = float(0.25)   # so hum effect is 25% of the total air quality score
-gas_weighting = float(0.75)   # so gas effect is 75% of the total air quality score
-
-sensor.set_humidity_oversample(bme680.OS_2X)
-sensor.set_pressure_oversample(bme680.OS_2X)
-sensor.set_temperature_oversample(bme680.OS_2X)
-sensor.set_filter(bme680.FILTER_SIZE_3)
-
-sensor.set_gas_heater_temperature(320)
-sensor.set_gas_heater_duration(150)
-sensor.select_gas_heater_profile(0)
-sensor.set_gas_status(bme680.ENABLE_GAS_MEAS)
-
-gas_reference = float(250000)
-hum_reference = float(40)
-getgasreference_count = int(0)
-
-
-def GetGasReference(gas_reference):
+def GetGasReference():
     # Now run the sensor for a burn-in period, then use combination of relative humidity and gas resistance to estimate indoor air quality as a percentage.
     # print("Getting a new gas reference value")
     readings = int(10)
+    gas_reference = 0
     while True:
         sensor.get_sensor_data()
         if sensor.data.heat_stable:
@@ -36,7 +14,8 @@ def GetGasReference(gas_reference):
                 sensor.get_sensor_data()
                 gas_reference = gas_reference + sensor.data.gas_resistance
             gas_reference = gas_reference / readings
-            return
+            return gas_reference
+
 
 def CalculateIAQ(score):
     IAQ_text = "Air quality is "
@@ -55,32 +34,65 @@ def CalculateIAQ(score):
         IAQ_text = IAQ_text + "Good"
     return IAQ_text
 
-#Calculate humidity contribution to IAQ index
-current_humidity = float(sensor.data.humidity)
-if (current_humidity >= 38 and current_humidity <= 42):
-    hum_score = float(0.25*100)  # Humidity +/-5% around optimum 
-else:
-  #sub-optimal
-    if (current_humidity < 38):
-        hum_score = float(0.25/hum_reference*current_humidity*100)
+
+if __name__ == "__main__":
+
+    try:
+        sensor = bme680.BME680(bme680.I2C_ADDR_PRIMARY)
+    except RuntimeError:
+        try:
+            sensor = bme680.BME680(bme680.I2C_ADDR_SECONDARY)
+        except Exception as ex:
+            print(ex)
+            quit(-1)
+
+    hum_weighting = float(0.25)  # so hum effect is 25% of the total air quality score
+    gas_weighting = float(0.75)  # so gas effect is 75% of the total air quality score
+
+    sensor.set_humidity_oversample(bme680.OS_2X)
+    sensor.set_pressure_oversample(bme680.OS_2X)
+    sensor.set_temperature_oversample(bme680.OS_2X)
+    sensor.set_filter(bme680.FILTER_SIZE_3)
+
+    sensor.get_sensor_data()
+    temperature = sensor.data.temperature
+    humidity = sensor.data.humidity
+
+    sensor.set_gas_heater_temperature(320)
+    sensor.set_gas_heater_duration(150)
+    sensor.select_gas_heater_profile(0)
+    sensor.set_gas_status(bme680.ENABLE_GAS_MEAS)
+
+    gas_reference = float(250000)
+    hum_reference = float(40)
+    getgasreference_count = int(0)
+
+    # Calculate humidity contribution to IAQ index
+    current_humidity = float(humidity)
+    if (current_humidity >= 38 and current_humidity <= 42):
+        hum_score = float(0.25 * 100)  # Humidity +/-5% around optimum
     else:
-        hum_score = ((-0.25/(100-hum_reference)*current_humidity)+0.416666)*100
+        # sub-optimal
+        if (current_humidity < 38):
+            hum_score = float(0.25 / hum_reference * current_humidity * 100)
+        else:
+            hum_score = ((-0.25 / (100 - hum_reference) * current_humidity) + 0.416666) * 100
 
-#Calculate gas contribution to IAQ index
-gas_lower_limit = float(5000)   # Bad air quality limit
-gas_upper_limit = float(50000)  # Good air quality limit
+    # Calculate gas contribution to IAQ index
+    gas_lower_limit = float(5000)  # Bad air quality limit
+    gas_upper_limit = float(50000)  # Good air quality limit
 
-if gas_reference > gas_upper_limit:  
-    gas_reference = gas_upper_limit
-if gas_reference < gas_lower_limit: 
-    gas_reference = gas_lower_limit
+    gas_reference = GetGasReference()
 
-gas_score = float((0.75/(gas_upper_limit-gas_lower_limit)*gas_reference -(gas_lower_limit*(0.75/(gas_upper_limit-gas_lower_limit))))*100)
+    if gas_reference > gas_upper_limit:
+        gas_reference = gas_upper_limit
+    if gas_reference < gas_lower_limit:
+        gas_reference = gas_lower_limit
 
-#Combine results for the final IAQ index value (0-100% where 100% is good quality air)
-air_quality_score = float(hum_score + gas_score)
+    gas_score = float((0.75 / (gas_upper_limit - gas_lower_limit) * gas_reference - (
+                gas_lower_limit * (0.75 / (gas_upper_limit - gas_lower_limit)))) * 100)
 
-GetGasReference(gas_reference)
+    # Combine results for the final IAQ index value (0-100% where 100% is good quality air)
+    air_quality_score = float(hum_score + gas_score)
 
-print('{0:0.1f}'.format(air_quality_score))
-
+    print('{:0.1f}|{:0.1f}|{:0.1f}'.format(temperature, humidity, air_quality_score))

--- a/octoprint_enclosure/__init__.py
+++ b/octoprint_enclosure/__init__.py
@@ -1183,7 +1183,7 @@ class EnclosurePlugin(octoprint.plugin.StartupPlugin, octoprint.plugin.TemplateP
 
     def read_bme680_temp(self, address):
         try:
-            script = os.path.dirname(os.path.realpath(__file__)) + "/BME680.py "
+            script = os.path.dirname(os.path.realpath(__file__)) + "/BME680.py"
             cmd = [sys.executable, script, str(address)]
             if self._settings.get(["use_sudo"]):
                 cmd.insert(0, "sudo")
@@ -1204,7 +1204,7 @@ class EnclosurePlugin(octoprint.plugin.StartupPlugin, octoprint.plugin.TemplateP
             self._logger.info(
                 "Failed to execute python scripts, try disabling use SUDO on advanced section of the plugin.")
             self.log_error(ex)
-            return (0, 0)
+            return (0, 0, 0)
 
     def read_am2320_temp(self):
         try:

--- a/octoprint_enclosure/static/js/enclosure.js
+++ b/octoprint_enclosure/static/js/enclosure.js
@@ -56,7 +56,7 @@ $(function () {
     self.notifications = ko.observableArray([]);
 
     self.humidityCapableSensor = function(sensor){
-      if (['11', '22', '2302', 'bme280', 'am2320', 'aht10' , 'si7021', 'hum_raw_i2c', 'temp_raw_i2c'].indexOf(sensor) >= 0){
+      if (['11', '22', '2302', 'bme280', 'bme680', 'am2320', 'aht10' , 'si7021', 'hum_raw_i2c', 'temp_raw_i2c'].indexOf(sensor) >= 0){
         return true;
       }
       return false;


### PR DESCRIPTION
Hello @vitormhenrique,

I also was having issues with this sensor mentioned in #462 and after some investigation, I found the root cause, a space in a filename in '__init__.py'.

This also led me to find some improper exception handling as well as some data that was not being read from the sensor, and therefore not being returned.

The changes below should fix the BME680 as well as enable it as a source of Humidity information.

Thanks,
Nathan