### PR TITLE
small fixes to work on Debian 12

### DIFF
--- a/octoprint_enclosure/__init__.py
+++ b/octoprint_enclosure/__init__.py
@@ -802,7 +802,7 @@ class EnclosurePlugin(octoprint.plugin.StartupPlugin, octoprint.plugin.TemplateP
             else:
                 sudo_str = ""
 
-            cmd = sudo_str + "python " + script + str(led_pin) + " " + str(led_count) + " " + str(
+            cmd = sudo_str + "/home/pi/oprint/bin/python " + script + str(led_pin) + " " + str(led_count) + " " + str(
                 led_brightness) + " " + str(red) + " " + str(green) + " " + str(blue) + " "
 
             if neopixel_dirrect:
@@ -1063,7 +1063,7 @@ class EnclosurePlugin(octoprint.plugin.StartupPlugin, octoprint.plugin.TemplateP
     def handle_temperature_events(self):
         for temperature_alarm in [item for item in self.rpi_outputs if item['output_type'] == 'temperature_alarm']:
             set_temperature = self.to_float(temperature_alarm['alarm_set_temp'])
-            if int(set_temperature) is 0:
+            if int(set_temperature) == 0:
                 continue
             linked_data = [item for item in self.temperature_sensor_data if
                            item['index_id'] == temperature_alarm['linked_temp_sensor']].pop()
@@ -1144,10 +1144,11 @@ class EnclosurePlugin(octoprint.plugin.StartupPlugin, octoprint.plugin.TemplateP
                 sudo_str = "sudo "
             else:
                 sudo_str = ""
-            cmd = sudo_str + "python3 " + script + str(sensor) + " " + str(pin)
+            cmd = sudo_str + "/home/pi/oprint/bin/python3 " + script + str(sensor) + " " + str(pin)
             if  self._settings.get(["debug_temperature_log"]) is True:
                 self._logger.debug("Temperature dht cmd: %s", cmd)
             stdout = (Popen(cmd, shell=True, stdout=PIPE).stdout).read()
+            self._logger.info(stdout.decode("utf-8"))
             if  self._settings.get(["debug_temperature_log"]) is True:
                 self._logger.debug("Dht result: %s", stdout)
             temp, hum = stdout.decode("utf-8").split("|")

--- a/octoprint_enclosure/getDHTTemp.py
+++ b/octoprint_enclosure/getDHTTemp.py
@@ -1,7 +1,7 @@
 import sys
 import time
 import adafruit_dht
-
+import board 
 
 # Parse command line parameters.
 sensor_args =   {
@@ -9,10 +9,26 @@ sensor_args =   {
                     '22': adafruit_dht.DHT22,
                     '2302': adafruit_dht.DHT22
                 }
+board_args = {
+        '1': board.D1,
+        '2': board.D2,
+        '3': board.D3,
+        '4': board.D4,
+        '5': board.D5,
+        '6': board.D6,
+        '7': board.D7,
+        '8': board.D8,
+        '9': board.D9,
+       '10': board.D10,
+       '11': board.D11,
+       '12': board.D12,
+       '13': board.D13,
+       '14': board.D14,
+        }
 
 if len(sys.argv) == 3 and sys.argv[1] in sensor_args:
     sensor = sensor_args[sys.argv[1]]
-    pin = sys.argv[2]
+    pin = board_args[sys.argv[2]]
 else:
     sys.exit(1)
 
@@ -29,7 +45,7 @@ while retry_count <= max_retries:
 
         if humidity is not None and temperature is not None:
             print('{0:0.1f} | {1:0.1f}'.format(temperature, humidity))
-            sys.exit(1)
+            sys.exit(0)
     except RuntimeError as e:
         time.sleep(2)
         retry_count += 1


### PR DESCRIPTION
This fixes issues with the new version of Adafruit DHT diver, and the need to run within Octoprint's venv on Debian 12. 